### PR TITLE
Small typo in GenerateTreeFromFile()

### DIFF
--- a/huflocal.c
+++ b/huflocal.c
@@ -115,7 +115,7 @@ huffman_node_t *GenerateTreeFromFile(FILE *inFile)
     huffmanTree = BuildHuffmanTree(huffmanArray, NUM_CHARS);
 
     /* deallocate any unused leaves */
-    for (c = 0; c < EOF; c++)
+    for (c = 0; c < EOF_CHAR; c++)
     {
         if (1 == huffmanArray[c]->ignore)
         {


### PR DESCRIPTION
Hi,

I found what I think is a small typo in GenerateTreeFromFile() while reviewing your repo. I noticed you looped on EOF (a constant that equals -1). I believe you meant to put EOF_CHAR there.

It might allow you to simplify the if condition in FindMinimumCount(), since you probably would not need to check for NULL and the ignore field, but I didn't look into if that would work.